### PR TITLE
Add H5P globals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,9 @@
 module.exports = {
+  globals: {
+    'H5P': 'readonly',
+    'H5PEditor': 'readonly',
+    'H5PIntegration': 'readonly'
+  },
   plugins: [
     'import',
   ],


### PR DESCRIPTION
When merged in, the default configuration will make `H5P`, `H5PEditor` and `H5PIntegration` known to eslint as global variables and set the flag to `readonly` as those should not be written to.

_(note: Technically, `H5PIntegration` should not be read either, but there are cases where the API of H5P core still doesn't provide any other way to learn about a couple of parameters that one may need.)_