### PR TITLE
Add rule for object-curly-spacing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     'arrow-parens': ['error', 'always'],
     'no-use-before-define': 'error',
     'import/no-extraneous-dependencies': 'warn',
-    'quotes': ['error', 'single']
+    'quotes': ['error', 'single'],
+    'object-curly-spacing': ['error', 'always']
   },
 };


### PR DESCRIPTION
When merged in, will add a rule for objects to always expect a spaces inside of braces (except `{}`). This is not specified by H5P Group, but we already are a little stricter and this would help to keep code a little more uniform. It's the preferred way of `prettier` for that matter. And I prefer it, too :-D